### PR TITLE
If NODE_ENV is not development, force TLS

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,6 @@ const EJS = require('ejs');
 const Inert = require('inert');
 const Vision = require('vision');
 const _ = require('lodash');
-const Fs = require('fs');
 
 var Path = require('path');
 var rootPath = '';
@@ -33,6 +32,7 @@ function setup( env, __dir ){
   environment.views = env.NODE_VIEWS_PATH || environment.views;
   environment.pages = env.WEB_PAGES || false;
   environment.domain = env.WEB_DOMAIN || 'http://127.0.0.1:6085';
+  environment.forceTls = env.NODE_ENV != "development"
 
   environment.aws = {
     accessKey: env.AWS_ACCESS_KEY || null,
@@ -56,18 +56,11 @@ function setup( env, __dir ){
 
   if( env.NODE_ENV === 'production'){
     delete environment.url;
-  } else {
-    if( env.TLS_CERT && env.TLS_KEY ) {
-      environment.tls = {
-        cert: Fs.readFileSync(env.TLS_CERT),
-        key: Fs.readFileSync(env.TLS_KEY)
-      };
-      environment.port = 443;
-    }
   }
 
   return environment;
 }
+
 var servidor = function( config ){
   const server = new Hapi.Server();
 
@@ -83,9 +76,6 @@ var servidor = function( config ){
 
   if( config.url ) {
     serverConfig.host = config.url;
-  }
-  if( config.tls ) {
-    serverConfig.tls = config.tls;
   }
 
   server.connection( serverConfig );
@@ -167,6 +157,13 @@ var servidor = function( config ){
   });
 
   server.userRole = config.userRole;
+
+    server.ext('onRequest', function(request, reply) {
+      if(server.mahr.forceTls){
+        return reply().redirect("https://"+request.headers.host+request.url.path).code(301)
+      }
+      return reply.continue();
+    })
 
   return server;
 }


### PR DESCRIPTION
This adds a check, inside the MAHRIO core server..

if a mahrio instance does not detect `NODE_ENV=='development'` it will force TLS.

This is required in order to properly redirect TLS, and still enable development of MAHRIO instances inside docker containers that cannot easily get TLS certs setup.. and for which there is little need until running in staging or production