### PR TITLE
Fix http redirect

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -181,7 +181,7 @@ var servidor = function( input_config) {
     server.ext('onRequest', function(request, h) {
         var redirect = request.headers['x-forwarded-proto'] === 'http' && server.mahr.forceTls;
         if( redirect ){
-          return h.redirect("https://"+request.headers.host+request.url.path).code(301)
+          return h.redirect("https://"+request.headers.host+request.url.path).code(301).takeover()
         }
         return h.continue;
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mahrio",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mahrio",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
https://futurestud.io/tutorials/hapi-how-to-fix-x-must-return-an-error-a-takeover-response-or-a-continue-signal

according to this, HAPIjs needs special commands on lifecycle extensions